### PR TITLE
fix: dev-experience grid

### DIFF
--- a/apps/web/src/components/landing/developer-experience.tsx
+++ b/apps/web/src/components/landing/developer-experience.tsx
@@ -86,9 +86,9 @@ export const DeveloperExperience = () => {
         </h2>
       </div>
 
-      <div className="grid lg:grid-cols-2 gap-8">
-        <div className="space-y-8">
-          <div className="bg-white/2 border border-white/5 rounded-3xl p-8 hover:border-white/10 transition-colors group">
+      <div className="grid lg:grid-cols-2 gap-8 items-stretch">
+        <div className="grid gap-8 lg:grid-rows-2">
+          <div className="bg-white/2 border border-white/5 rounded-3xl p-8 hover:border-white/10 transition-colors group h-full flex flex-col">
             <div className="flex items-center gap-4 mb-6">
               <div className="w-10 h-10 rounded-full bg-accent/10 flex items-center justify-center group-hover:bg-accent/20 transition-colors">
                 <TerminalIcon size={20} className="text-accent" />
@@ -100,12 +100,12 @@ export const DeveloperExperience = () => {
             <p className="text-white/40 mb-6">
               One command, you're online. Seriously, try for yourself.
             </p>
-            <div className="bg-black/40 rounded-2xl border border-white/5 p-4 font-mono text-sm">
+            <div className="bg-black/40 rounded-2xl border border-white/5 p-4 font-mono text-sm mt-auto">
               <span className="text-accent">$</span> outray 3000
             </div>
           </div>
 
-          <div className="bg-white/2 border border-white/5 rounded-3xl p-8 hover:border-white/10 transition-colors group">
+          <div className="bg-white/2 border border-white/5 rounded-3xl p-8 hover:border-white/10 transition-colors group h-full flex flex-col">
             <div className="flex items-center gap-4 mb-6">
               <div className="w-10 h-10 rounded-full bg-accent/10 flex items-center justify-center group-hover:bg-accent/20 transition-colors">
                 <Code size={20} className="text-accent" />
@@ -120,7 +120,7 @@ export const DeveloperExperience = () => {
             <p className="text-white/40 mb-6">
               Use our SDKs to embed OutRay directly into your app.
             </p>
-            <div className="bg-black/40 rounded-2xl border border-white/5 p-4 font-mono text-sm overflow-x-auto">
+            <div className="bg-black/40 rounded-2xl border border-white/5 p-4 font-mono text-sm overflow-x-auto mt-auto">
               <span className="text-accent">import</span> outray{" "}
               <span className="text-accent">from</span>{" "}
               <span className="text-white/60">"outray"</span>;{"\n"}
@@ -131,10 +131,10 @@ export const DeveloperExperience = () => {
           </div>
         </div>
 
-        <div className="bg-white/2 border border-white/5 rounded-3xl p-8 flex flex-col relative overflow-hidden group">
+        <div className="bg-white/2 border border-white/5 rounded-3xl p-8 flex flex-col relative overflow-hidden group h-full">
           <div className="absolute top-0 right-0 w-64 h-64 bg-accent/10 rounded-full blur-3xl -mr-32 -mt-32 pointer-events-none group-hover:bg-accent/20 transition-colors" />
 
-          <div className="mb-8">
+          <div>
             <div className="flex items-center gap-4 mb-6">
               <div className="w-10 h-10 rounded-full bg-accent/10 flex items-center justify-center group-hover:bg-accent/20 transition-colors">
                 <Activity size={20} className="text-accent" />
@@ -149,7 +149,7 @@ export const DeveloperExperience = () => {
             </p>
           </div>
 
-          <div className="mt-auto space-y-3 font-mono text-xs min-h-96 flex flex-col justify-end">
+          <div className="mt-8 space-y-3 font-mono text-xs flex-1 flex flex-col justify-end">
             <AnimatePresence mode="popLayout" initial={false}>
               {visibleLogs.map((log) => (
                 <motion.div


### PR DESCRIPTION
Before: 
<img width="1291" height="819" alt="image" src="https://github.com/user-attachments/assets/c7325895-8276-4cac-b888-dcfc8e72620a" />
After
<img width="1288" height="770" alt="image" src="https://github.com/user-attachments/assets/687cc16c-bad5-4442-905b-f8387916d456" />

Very small detail idk this is good or not, let me know if you think i should make any changes,
also i have a question on a different component

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Developer Experience grid so both columns align and cards have equal height on large screens. Code examples and logs now stick to the bottom, and the logs panel grows to fill the available space.

- **Bug Fixes**
  - Applied items-stretch to the grid and made the left column a two-row grid.
  - Set cards to h-full with flex layout; anchored code blocks with mt-auto.
  - Updated the right panel to flex-1 with justify-end; removed min-h-96 and excess margins to eliminate gaps.

<sup>Written for commit c9c14610fa73ac38f092ed9661ef020e2a7006eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

