### PR TITLE
fix: prevent new terminal from opening on Windows login

### DIFF
--- a/apps/cli/src/auth.ts
+++ b/apps/cli/src/auth.ts
@@ -148,7 +148,7 @@ export class AuthManager {
       platform === "darwin"
         ? `open "${url}"`
         : platform === "win32"
-          ? `start "${url}"`
+          ? `cmd /c start "" "${url}"`
           : `xdg-open "${url}"`;
 
     exec(command, (error) => {


### PR DESCRIPTION
Fixes an issue on Windows where running the login command opens a new terminal window instead of the default browser. The root cause is that `start` is a cmd.exe built-in and, when invoked directly, misinterprets the quoted URL as a window title.

The command is now executed using `cmd /c start "" "<url>"`, which correctly launches the authentication URL in the user’s default browser and prevents the creation of an extra Command Prompt window.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a new Command Prompt window from opening during Windows login by launching the auth URL with cmd /c start "" "<url>", which correctly opens the default browser.

<sup>Written for commit a817d00c252b18be4d3392221028bcc350184a47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

