### PR TITLE
fix: patch auth bypass, rate limiting, timing attacks, XSS, and memory leaks

### DIFF
--- a/apps/cron/.env.example
+++ b/apps/cron/.env.example
@@ -2,4 +2,13 @@
 REDIS_URL=redis://localhost:6379
 
 # TimescaleDB (TigerData)
+# If your connection string includes ?sslmode=require, you don't need to set SSL_MODE
 TIGER_DATA_URL=postgresql://localhost:5432/outray
+
+# SSL Mode (optional - leave empty to use connection string's sslmode)
+# Options: "" (auto), "disable", "require", "verify-ca", "verify-full"
+# TIGER_DATA_SSL_MODE=
+
+# Custom CA certificate (base64 encoded, optional)
+# Only needed for self-signed certificates or private CAs
+# TIGER_DATA_SSL_CA=

--- a/apps/cron/src/config.ts
+++ b/apps/cron/src/config.ts
@@ -6,4 +6,8 @@ export const config = {
   redisUrl: process.env.REDIS_URL || "redis://localhost:6379",
   tigerDataUrl:
     process.env.TIGER_DATA_URL || "postgresql://localhost:5432/outray",
+  // SSL mode: "" (auto/use connection string), "disable", "require", "verify-ca", "verify-full"
+  // Default empty string means pg will use sslmode from connection string if present
+  tigerDataSslMode: process.env.TIGER_DATA_SSL_MODE || "",
+  tigerDataSslCa: process.env.TIGER_DATA_SSL_CA || "",
 };

--- a/apps/cron/src/index.ts
+++ b/apps/cron/src/index.ts
@@ -1,6 +1,3 @@
-// Allow self-signed certificates for Tiger Data cloud
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-
 import { redis } from "./lib/redis";
 import { pool, execute } from "./lib/tigerdata";
 

--- a/apps/cron/src/lib/tigerdata.ts
+++ b/apps/cron/src/lib/tigerdata.ts
@@ -3,11 +3,54 @@ import { config } from "../config";
 
 const { Pool } = pg;
 
+/**
+ * Determine SSL configuration based on environment.
+ *
+ * SSL Modes:
+ * - "" (empty/auto): Let pg use sslmode from connection string (default)
+ * - "disable": Explicitly disable SSL
+ * - "require": Use SSL but don't verify certificates
+ * - "verify-ca": Use SSL, verify CA certificate
+ * - "verify-full": Use SSL, verify CA certificate and hostname
+ *
+ * TIGER_DATA_SSL_CA can be set to a base64-encoded CA certificate for custom CAs.
+ */
+function getSSLConfig(): pg.PoolConfig["ssl"] {
+  const sslMode = config.tigerDataSslMode;
+
+  // Empty/auto: don't override, let pg use connection string's sslmode
+  if (!sslMode) {
+    return undefined;
+  }
+
+  // Explicitly disable SSL
+  if (sslMode === "disable") {
+    return false;
+  }
+
+  // SSL enabled modes
+  if (sslMode === "require" || sslMode === "verify-ca" || sslMode === "verify-full") {
+    const sslConfig: pg.ConnectionOptions["ssl"] = {
+      // require: don't verify, verify-ca/verify-full: verify
+      rejectUnauthorized: sslMode !== "require",
+    };
+
+    // If a custom CA certificate is provided (base64 encoded)
+    if (config.tigerDataSslCa) {
+      sslConfig.ca = Buffer.from(config.tigerDataSslCa, "base64").toString("utf-8");
+    }
+
+    return sslConfig;
+  }
+
+  // Unknown mode - log warning and use auto (undefined)
+  console.warn(`Unknown TIGER_DATA_SSL_MODE: "${sslMode}", using connection string default`);
+  return undefined;
+}
+
 export const pool = new Pool({
   connectionString: config.tigerDataUrl,
-  ssl: {
-    rejectUnauthorized: false,
-  },
+  ssl: getSSLConfig(),
 });
 
 export async function query<T>(text: string, params?: unknown[]): Promise<T[]> {

--- a/apps/tunnel/.env.example
+++ b/apps/tunnel/.env.example
@@ -21,3 +21,6 @@ UDP_PORT_RANGE_MAX=40000
 
 # Web API URL (for tunnel registration)
 WEB_API_URL=http://localhost:3000/api
+
+# Internal API Secret (shared with web app for server-to-server auth)
+INTERNAL_API_SECRET=your_secure_random_secret_here

--- a/apps/tunnel/src/config.ts
+++ b/apps/tunnel/src/config.ts
@@ -3,6 +3,8 @@ import "dotenv/config";
 export const config = {
   port: parseInt(process.env.PORT || "3547", 10),
   baseDomain: process.env.BASE_DOMAIN || "localhost.direct",
+  webApiUrl: process.env.WEB_API_URL || "http://localhost:3000/api",
+  internalApiSecret: process.env.INTERNAL_API_SECRET || "",
   redisUrl: process.env.REDIS_URL || "redis://127.0.0.1:6379",
   redisTunnelTtlSeconds: parseInt(
     process.env.REDIS_TUNNEL_TTL_SECONDS || "120",

--- a/apps/tunnel/src/core/HTTPProxy.ts
+++ b/apps/tunnel/src/core/HTTPProxy.ts
@@ -225,7 +225,23 @@ export class HTTPProxy {
     return ip;
   }
 
+  /**
+   * Escape HTML special characters to prevent XSS attacks.
+   * The tunnelId comes from user-controlled hostnames (custom domains).
+   */
+  private escapeHtml(unsafe: string): string {
+    return unsafe
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
   private getOfflineHtml(tunnelId: string): string {
+    // Escape tunnelId to prevent XSS attacks from malicious custom domains
+    const safeTunnelId = this.escapeHtml(tunnelId);
+
     try {
       const paths = [
         path.join(__dirname, "../offline.html"), // Dev: src/core/../offline.html -> src/offline.html
@@ -242,17 +258,20 @@ export class HTTPProxy {
       }
 
       if (!template) {
-        return `<h1>${tunnelId} is offline</h1>`;
+        return `<h1>${safeTunnelId} is offline</h1>`;
       }
 
-      return template.replace(/{{TUNNEL_ID}}/g, tunnelId);
+      return template.replace(/{{TUNNEL_ID}}/g, safeTunnelId);
     } catch (error) {
       console.error("Failed to load offline page template", error);
-      return `<h1>${tunnelId} is offline</h1>`;
+      return `<h1>${safeTunnelId} is offline</h1>`;
     }
   }
 
   private getBandwidthExceededHtml(tunnelId: string): string {
+    // Escape tunnelId to prevent XSS attacks from malicious custom domains
+    const safeTunnelId = this.escapeHtml(tunnelId);
+
     try {
       const paths = [
         path.join(__dirname, "../bandwidth_exceeded.html"),
@@ -269,13 +288,13 @@ export class HTTPProxy {
       }
 
       if (!template) {
-        return `<h1>Bandwidth Limit Exceeded for ${tunnelId}</h1>`;
+        return `<h1>Bandwidth Limit Exceeded for ${safeTunnelId}</h1>`;
       }
 
-      return template.replace(/{{TUNNEL_ID}}/g, tunnelId);
+      return template.replace(/{{TUNNEL_ID}}/g, safeTunnelId);
     } catch (error) {
       console.error("Failed to load bandwidth exceeded page template", error);
-      return `<h1>Bandwidth Limit Exceeded for ${tunnelId}</h1>`;
+      return `<h1>Bandwidth Limit Exceeded for ${safeTunnelId}</h1>`;
     }
   }
 }

--- a/apps/tunnel/src/core/LogManager.ts
+++ b/apps/tunnel/src/core/LogManager.ts
@@ -4,10 +4,72 @@ import { TunnelEvent } from "../lib/tigerdata";
 export class LogManager {
   private logs = new Map<string, TunnelEvent[]>();
   private subscribers = new Map<string, Set<WebSocket>>();
+  private lastActivity = new Map<string, number>();
+  private cleanupInterval: NodeJS.Timeout | null = null;
+
+  // Maximum time (in ms) to keep logs for orgs with no subscribers
+  private readonly STALE_LOG_TTL_MS = 5 * 60 * 1000; // 5 minutes
+  // Cleanup interval
+  private readonly CLEANUP_INTERVAL_MS = 60 * 1000; // 1 minute
+
+  constructor() {
+    // Start periodic cleanup of stale logs to prevent memory leaks
+    this.cleanupInterval = setInterval(() => {
+      this.cleanupStaleLogs();
+    }, this.CLEANUP_INTERVAL_MS);
+
+    // Allow the timer to not prevent the process from exiting
+    if (typeof this.cleanupInterval.unref === "function") {
+      this.cleanupInterval.unref();
+    }
+  }
+
+  /**
+   * Cleanup logs for organizations that have no active subscribers
+   * and haven't had activity in STALE_LOG_TTL_MS.
+   */
+  private cleanupStaleLogs(): void {
+    const now = Date.now();
+    const staleOrgs: string[] = [];
+
+    for (const [orgId, lastActivityTime] of this.lastActivity) {
+      const hasSubscribers = this.subscribers.has(orgId) &&
+                             this.subscribers.get(orgId)!.size > 0;
+
+      if (!hasSubscribers && now - lastActivityTime > this.STALE_LOG_TTL_MS) {
+        staleOrgs.push(orgId);
+      }
+    }
+
+    for (const orgId of staleOrgs) {
+      this.logs.delete(orgId);
+      this.lastActivity.delete(orgId);
+    }
+
+    if (staleOrgs.length > 0) {
+      console.log(`[LogManager] Cleaned up logs for ${staleOrgs.length} stale organizations`);
+    }
+  }
+
+  /**
+   * Shutdown the log manager and cleanup resources.
+   */
+  shutdown(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
+    this.logs.clear();
+    this.subscribers.clear();
+    this.lastActivity.clear();
+  }
 
   addLog(event: TunnelEvent) {
     const orgId = event.organization_id;
     if (!orgId) return;
+
+    // Track last activity time for cleanup purposes
+    this.lastActivity.set(orgId, Date.now());
 
     let orgLogs = this.logs.get(orgId);
     if (!orgLogs) {

--- a/apps/tunnel/src/server.ts
+++ b/apps/tunnel/src/server.ts
@@ -75,12 +75,96 @@ const wsHandler = new WSHandler(wssTunnel, router, tcpProxy, udpProxy);
 
 console.log("✅ TCP/UDP tunnel support enabled");
 
-wssDashboard.on("connection", (ws, req) => {
+/**
+ * Validate that a token has access to the specified organization.
+ * Supports two token types:
+ * 1. Dashboard WebSocket tokens (short-lived, stored in Redis) - for web dashboard users
+ * 2. CLI org tokens (validated via /api/tunnel/auth) - for CLI users
+ */
+async function validateDashboardAccess(
+  token: string,
+  orgId: string
+): Promise<{ valid: boolean; error?: string }> {
+  try {
+    // First, try to validate as a dashboard WebSocket token (stored in Redis)
+    const dashboardTokenKey = `dashboard:ws:${token}`;
+    const dashboardTokenData = await redis.get(dashboardTokenKey);
+
+    if (dashboardTokenData) {
+      try {
+        const tokenInfo = JSON.parse(dashboardTokenData) as {
+          organizationId: string;
+          userId: string;
+          createdAt: number;
+        };
+
+        // Verify the token's organization matches the requested orgId
+        if (tokenInfo.organizationId !== orgId) {
+          return { valid: false, error: "Access denied to this organization" };
+        }
+
+        // Token is valid - optionally delete it for one-time use
+        // await redis.del(dashboardTokenKey);
+
+        return { valid: true };
+      } catch (parseError) {
+        console.error("Failed to parse dashboard token data:", parseError);
+      }
+    }
+
+    // Fall back to CLI org token validation via API
+    const response = await fetch(`${config.webApiUrl}/tunnel/auth`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+
+    if (!response.ok) {
+      return { valid: false, error: "Authentication failed" };
+    }
+
+    const result = (await response.json()) as {
+      valid: boolean;
+      organizationId?: string;
+      error?: string;
+    };
+
+    if (!result.valid) {
+      return { valid: false, error: result.error || "Invalid token" };
+    }
+
+    // Verify the token's organization matches the requested orgId
+    if (result.organizationId !== orgId) {
+      return { valid: false, error: "Access denied to this organization" };
+    }
+
+    return { valid: true };
+  } catch (error) {
+    console.error("Dashboard auth validation error:", error);
+    return { valid: false, error: "Authentication service unavailable" };
+  }
+}
+
+wssDashboard.on("connection", async (ws, req) => {
   const url = new URL(req.url || "", "http://localhost");
   const orgId = url.searchParams.get("orgId");
+  const token = url.searchParams.get("token");
 
   if (!orgId) {
     ws.close(1008, "Organization ID required");
+    return;
+  }
+
+  if (!token) {
+    ws.close(1008, "Authentication token required");
+    return;
+  }
+
+  // Validate the token has access to this organization
+  const authResult = await validateDashboardAccess(token, orgId);
+  if (!authResult.valid) {
+    console.log(`Dashboard access denied for org ${orgId}: ${authResult.error}`);
+    ws.close(1008, authResult.error || "Unauthorized");
     return;
   }
 
@@ -120,12 +204,13 @@ httpServer.listen(config.port, () => {
 const shutdown = async () => {
   console.log("Shutting down tunnel server...");
   wsHandler.shutdown();
+  logManager.shutdown();
   await router.shutdown();
   await redis.quit();
-  
+
   // Flush buffered logs and close database connection
   await shutdownLoggers();
-  
+
   httpServer.close(() => process.exit(0));
 };
 

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -33,3 +33,9 @@ POLAR_SERVER=sandbox
 # Polar Product IDs
 POLAR_PRODUCT_RAY=prod_xxxxxxxxxxxxxxxx
 POLAR_PRODUCT_BEAM=prod_xxxxxxxxxxxxxxxx
+
+# Admin Dashboard
+ADMIN_PASSPHRASE=your_secure_admin_passphrase
+
+# Internal API Secret (shared with tunnel server for server-to-server auth)
+INTERNAL_API_SECRET=your_secure_random_secret_here

--- a/apps/web/src/lib/rate-limiter.ts
+++ b/apps/web/src/lib/rate-limiter.ts
@@ -83,12 +83,14 @@ export async function rateLimit(
         };
     } catch (error) {
         console.error("Rate limit error:", error);
+        // SECURITY: Fail closed - deny requests when rate limiting is unavailable
+        // This prevents bypass attacks when Redis is down or experiencing errors
         return {
-            allowed: true,
-            current: 0,
+            allowed: false,
+            current: config.maxRequests,
             limit: config.maxRequests,
             resetIn: config.windowSeconds,
-            remaining: config.maxRequests,
+            remaining: 0,
         };
     }
 }

--- a/apps/web/src/routes/api/$orgSlug/dashboard-token.ts
+++ b/apps/web/src/routes/api/$orgSlug/dashboard-token.ts
@@ -1,0 +1,58 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { json } from "@tanstack/react-start";
+import { randomBytes } from "crypto";
+import { requireOrgFromSlug } from "../../../lib/org";
+import { redis } from "../../../lib/redis";
+
+// Dashboard WebSocket tokens are short-lived (5 minutes)
+const DASHBOARD_TOKEN_TTL_SECONDS = 300;
+
+export const Route = createFileRoute("/api/$orgSlug/dashboard-token")({
+  server: {
+    handlers: {
+      /**
+       * Generate a short-lived token for dashboard WebSocket authentication.
+       * This allows session-authenticated users to connect to the real-time
+       * dashboard WebSocket on the tunnel server.
+       */
+      POST: async ({ request, params }) => {
+        try {
+          const { orgSlug } = params;
+
+          // Validate session and org membership
+          const orgContext = await requireOrgFromSlug(request, orgSlug);
+          if ("error" in orgContext) {
+            return orgContext.error;
+          }
+
+          // Generate a short-lived token
+          const token = randomBytes(32).toString("hex");
+          const tokenKey = `dashboard:ws:${token}`;
+
+          // Store token with org info in Redis
+          await redis.set(
+            tokenKey,
+            JSON.stringify({
+              organizationId: orgContext.organization.id,
+              userId: orgContext.session?.user.id,
+              createdAt: Date.now(),
+            }),
+            "EX",
+            DASHBOARD_TOKEN_TTL_SECONDS
+          );
+
+          return json({
+            token,
+            expiresIn: DASHBOARD_TOKEN_TTL_SECONDS,
+          });
+        } catch (error) {
+          console.error("Dashboard token generation error:", error);
+          return json(
+            { error: "Failed to generate dashboard token" },
+            { status: 500 }
+          );
+        }
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/api/admin/login.ts
+++ b/apps/web/src/routes/api/admin/login.ts
@@ -1,16 +1,52 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { json } from "@tanstack/react-start";
-import { randomUUID } from "crypto";
+import { randomUUID, timingSafeEqual, createHash } from "crypto";
 import { redis } from "../../../lib/redis";
 import { hashToken } from "../../../lib/hash";
+import {
+  rateLimit,
+  getClientIdentifier,
+  createRateLimitResponse,
+} from "../../../lib/rate-limiter";
 
 const PASSPHRASE = process.env.ADMIN_PASSPHRASE;
 const TOKEN_TTL_SECONDS = 60 * 60; // 1h
+
+/**
+ * Timing-safe passphrase comparison to prevent timing attacks.
+ * Uses SHA-256 hashing to ensure constant-length comparison regardless of input length.
+ * Returns true if the phrases match, false otherwise.
+ */
+function safeComparePassphrase(input: string, expected: string): boolean {
+  // Ensure both strings exist and have content
+  if (!input || !expected) {
+    return false;
+  }
+
+  // Hash both inputs to get fixed-length buffers
+  // This prevents length-based timing attacks
+  const inputHash = createHash("sha256").update(input).digest();
+  const expectedHash = createHash("sha256").update(expected).digest();
+
+  return timingSafeEqual(inputHash, expectedHash);
+}
 
 export const Route = createFileRoute("/api/admin/login")({
   server: {
     handlers: {
       POST: async ({ request }) => {
+        // Rate limit: 5 attempts per minute per IP (strict for admin login)
+        const clientId = getClientIdentifier(request);
+        const rateLimitResult = await rateLimit(clientId, {
+          identifier: "admin-login",
+          maxRequests: 5,
+          windowSeconds: 60,
+        });
+
+        if (!rateLimitResult.allowed) {
+          return createRateLimitResponse(rateLimitResult);
+        }
+
         if (!PASSPHRASE) {
           return json(
             { error: "Admin passphrase not configured" },
@@ -30,7 +66,8 @@ export const Route = createFileRoute("/api/admin/login")({
           return json({ error: "Phrase required" }, { status: 400 });
         }
 
-        if (phrase !== PASSPHRASE) {
+        // Use timing-safe comparison to prevent timing attacks
+        if (!safeComparePassphrase(phrase, PASSPHRASE)) {
           return json({ error: "Unauthorized" }, { status: 401 });
         }
 

--- a/apps/web/src/routes/api/domain/verify-ownership.ts
+++ b/apps/web/src/routes/api/domain/verify-ownership.ts
@@ -1,14 +1,58 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { json } from "@tanstack/react-start";
 import { and, eq } from "drizzle-orm";
+import { timingSafeEqual, createHash } from "crypto";
 import { db } from "../../../db";
 import { domains } from "../../../db/app-schema";
+import {
+  rateLimit,
+  getClientIdentifier,
+  createRateLimitResponse,
+} from "../../../lib/rate-limiter";
+
+// Internal API secret for server-to-server authentication
+// This endpoint should only be called by the tunnel server
+const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET;
+
+/**
+ * Timing-safe secret comparison using hashing for constant-length buffers.
+ */
+function safeCompareSecret(input: string | null, expected: string): boolean {
+  if (!input) return false;
+
+  const inputHash = createHash("sha256").update(input).digest();
+  const expectedHash = createHash("sha256").update(expected).digest();
+
+  return timingSafeEqual(inputHash, expectedHash);
+}
 
 export const Route = createFileRoute("/api/domain/verify-ownership")({
   server: {
     handlers: {
       POST: async ({ request }) => {
         try {
+          // Rate limit to prevent enumeration attacks
+          const clientId = getClientIdentifier(request);
+          const rateLimitResult = await rateLimit(clientId, {
+            identifier: "domain-verify",
+            maxRequests: 30,
+            windowSeconds: 60,
+          });
+
+          if (!rateLimitResult.allowed) {
+            return createRateLimitResponse(rateLimitResult);
+          }
+
+          // Verify internal API secret for server-to-server calls
+          // This prevents external enumeration of domain ownership
+          const authHeader = request.headers.get("x-internal-secret");
+          if (INTERNAL_API_SECRET && !safeCompareSecret(authHeader, INTERNAL_API_SECRET)) {
+            return json(
+              { valid: false, error: "Unauthorized" },
+              { status: 401 }
+            );
+          }
+
           const body = (await request.json()) as {
             domain?: string;
             organizationId?: string;


### PR DESCRIPTION

This PR resolves security vulnerabilities on the OutRay repo, which includes issues with Rate limiting, XSS, & Memory leaks.

## What the issues are?
 - The dashboard WebSocket at /dashboard/events has zero authentication. Anyone who knows an org ID can connect and watch all their real-time tunnel logs. Not ideal.
  - The cron job has NODE_TLS_REJECT_UNAUTHORIZED = "0" at the top which completely disables SSL certificate verification. This was probably added to get around a self-signed cert issue but it's still a massive security issue.
  - Rate limiter returns allowed: true when Redis fails. So if someone DoS's Redis, they can bypass all rate limits.
  - Admin login has no rate limiting at all, you can brute force the passphrase forever. Also the string comparison wasn't timing-safe.
  - The /api/domain/verify-ownership endpoint has no auth, so anyone can enumerate which domains belong to which orgs.
  - Tunnel IDs get injected into HTML error pages without escaping. Since tunnel IDs come from hostnames (including custom domains), this is an XSS vector.
  - LogManager keeps logs in memory forever for orgs that don't have active dashboard connections. Possible memeory leak over time.
  
## What did I change?
### Auth & Rate Limiting:
  - Dashboard WebSocket now requires a token. Web users call POST /api/{orgSlug}/dashboard-token to get a short-lived token (5 min), and CLI users can use their existing org token
  - Admin login now has rate limiting (5 attempts/min) and uses proper timing-safe comparison (SHA-256 hash before comparing to avoid length leaks)
  - Domain verification endpoint now requires an internal API secret for server-to-server calls
  - Rate limiter now fails closed in the situation when Redis is down, requests are denied instead of allowed

### TLS:
  - Removed the global NODE_TLS_REJECT_UNAUTHORIZED = "0" from cron
  - Added proper SSL config via env vars. Default is empty, which means "use whatever's in the connection string," so existing setups won't break

### XSS & Memory:
  - Tunnel IDs are now HTML-escaped before being inserted into error pages
  - LogManager cleans up logs for inactive orgs every 60 seconds (5 min TTL)

What are possible breaking changes?
  Dashboard WebSocket requires auth now. Frontend needs to:
  1. POST /api/{orgSlug}/dashboard-token → get a token
  2. Connect to wss://tunnel-server/dashboard/events?orgId=xxx&token=yyy

  New env vars
``` bash
  # Tunnel server
  INTERNAL_API_SECRET=generate-a-random-string

  # Web app
  INTERNAL_API_SECRET=same-string-as-tunnel
  ADMIN_PASSPHRASE=your-admin-passphrase

  # Cron (all optional - leave unset to use connection string's sslmode)
  # TIGER_DATA_SSL_MODE=verify-full
  # TIGER_DATA_SSL_CA=base64-encoded-cert
```

 Testing requirements to make sure everything works as expected

  - Dashboard WebSocket rejects connections without valid token
  - Dashboard WebSocket works with valid token from /dashboard-token endpoint
  - Admin login blocks after 5 failed attempts
  - Cron connects to TimescaleDB properly
  - Error pages don't execute JS if you put <script> in a tunnel name