### PR TITLE
optimize tunnel counting from O(n) SCAN to O(1)

### DIFF
--- a/apps/cron/src/index.ts
+++ b/apps/cron/src/index.ts
@@ -39,18 +39,27 @@ async function sampleActiveTunnels() {
 
     let totalCount = 0;
 
-    let cursor = "0";
-    do {
-      const [nextCursor, keys] = await redis.scan(
-        cursor,
-        "MATCH",
-        "tunnel:online:*",
-        "COUNT",
-        1000,
-      );
-      cursor = nextCursor;
-      totalCount += keys.length;
-    } while (cursor !== "0");
+    // Use global counter for O(1) lookup instead of O(n) SCAN
+    const countStr = await redis.get("tunnel:global:online_count");
+    if (countStr !== null) {
+      totalCount = parseInt(countStr, 10) || 0;
+    } else {
+      // Fallback: counter doesn't exist yet, use SCAN (only happens on first run)
+      let cursor = "0";
+      do {
+        const [nextCursor, keys] = await redis.scan(
+          cursor,
+          "MATCH",
+          "tunnel:online:*",
+          "COUNT",
+          1000,
+        );
+        cursor = nextCursor;
+        totalCount += keys.length;
+      } while (cursor !== "0");
+      // Initialize the counter for future runs
+      await redis.set("tunnel:global:online_count", totalCount.toString());
+    }
 
     console.log("Active tunnels:", totalCount);
 


### PR DESCRIPTION
Maintain a global atomic counter (tunnel:global:online_count) that 
gets incremented/decremented by TunnelRouter when tunnels come 
online/offline.
- Added GLOBAL_ONLINE_COUNT_KEY constant to TunnelRouter
- Increment counter in persistTunnelState on successful registration
- Decrement counter in unregisterTunnel
- Updated cron job to read counter with GET instead of SCAN
- Added fallback to SCAN for backward compatibility on first run
This eliminates the expensive SCAN operation that iterates through
all Redis keys, critical for scaling to thousands of active tunnels.