### PR TITLE
fix: forward browser headers in WebSocket upgrade handshake

### DIFF
--- a/apps/cli/src/client.ts
+++ b/apps/cli/src/client.ts
@@ -409,11 +409,16 @@ export class OutRayClient {
 
     try {
       const headers: Record<string, string> = {};
-      if (message.protocol) {
-        headers["Sec-WebSocket-Protocol"] = message.protocol;
+      for (const key of ["authorization", "cookie", "origin", "referer", "user-agent"] as const) {
+        const value = message.headers[key];
+        if (typeof value === "string") {
+          headers[key] = value;
+        }
       }
 
-      const localWs = new WebSocket(wsUrl, { headers });
+      const localWs = message.protocol
+        ? new WebSocket(wsUrl, [message.protocol], { headers })
+        : new WebSocket(wsUrl, { headers });
 
       localWs.on("open", () => {
         this.localWebSockets.set(message.wsConnectionId, localWs);

--- a/apps/tunnel/src/core/WSProxy.ts
+++ b/apps/tunnel/src/core/WSProxy.ts
@@ -81,26 +81,44 @@ export class WSProxy {
       timeout,
     });
 
-    // Build headers to forward (filter out hop-by-hop headers)
-    const headers: Record<string, string | string[]> = {};
-    for (const [key, value] of Object.entries(request.headers)) {
-      if (value !== undefined) {
-        headers[key] = value;
-      }
-    }
-
     // Send ws_upgrade to the tunnel client
     tunnelWs.send(
       Protocol.encode({
         type: "ws_upgrade",
         wsConnectionId,
         path: request.url || "/",
-        headers,
+        headers: this.buildForwardHeaders(request.headers),
         protocol: request.headers["sec-websocket-protocol"],
       })
     );
 
     console.log(`→ WebSocket upgrade requested: ${tunnelId}${request.url} (${wsConnectionId})`);
+  }
+
+  private buildForwardHeaders(
+    headers: IncomingMessage["headers"],
+  ): Record<string, string | string[]> {
+    // Preserve headers that commonly matter for WebSocket servers while stripping hop-by-hop upgrade headers that should not be replayed.
+    const forwarded: Record<string, string | string[]> = {};
+    const allowed = new Set([
+      "authorization",
+      "cookie",
+      "origin",
+      "referer",
+      "user-agent",
+      "sec-websocket-protocol",
+      "x-forwarded-for",
+      "x-forwarded-host",
+      "x-forwarded-proto",
+    ]);
+
+    for (const [key, value] of Object.entries(headers)) {
+      if (value !== undefined && allowed.has(key.toLowerCase())) {
+        forwarded[key] = value;
+      }
+    }
+
+    return forwarded;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "zustand": "^5.0.9"
       },
       "devDependencies": {
+        "socket.io": "^4.8.3",
         "typescript": "^5.7.2"
       }
     },
@@ -4308,6 +4309,13 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
@@ -5087,6 +5095,16 @@
       "resolved": "https://registry.npmjs.org/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz",
       "integrity": "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==",
       "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/d3": {
       "version": "7.4.3",
@@ -5886,6 +5904,30 @@
       "integrity": "sha512-3ab1B59Ojb6RwjOspYLsTpCzbNB3ZaamIAxBMmvnNkiDoLTZUOBXZ9p5nAYVEkQlDdf6qAZWi1pqj9+ypiqznA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -6129,6 +6171,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.14",
@@ -6721,6 +6773,16 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-es": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
@@ -6744,6 +6806,24 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cose-base": {
       "version": "1.0.3",
@@ -7836,6 +7916,38 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.9",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+      "integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -14160,6 +14272,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+      "integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.21.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -16279,6 +16435,16 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -17089,9 +17255,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": "cd apps/tunnel && npm run build && cd ../cli && npm run build && cd ../web && npm run build"
   },
   "devDependencies": {
+    "socket.io": "^4.8.3",
     "typescript": "^5.7.2"
   },
   "dependencies": {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -266,14 +266,16 @@ export class OutrayClient {
 
     try {
       const headers: Record<string, string> = {};
-      // Forward relevant headers (like subprotocols)
-      if (message.protocol) {
-        headers["Sec-WebSocket-Protocol"] = message.protocol;
+      for (const key of ["authorization", "cookie", "origin", "referer", "user-agent"] as const) {
+        const value = message.headers[key];
+        if (typeof value === "string") {
+          headers[key] = value;
+        }
       }
 
-      const localWs = new WebSocket(wsUrl, {
-        headers,
-      });
+      const localWs = message.protocol
+        ? new WebSocket(wsUrl, [message.protocol], { headers })
+        : new WebSocket(wsUrl, { headers });
 
       localWs.on("open", () => {
         this.localWebSockets.set(message.wsConnectionId, localWs);

--- a/packages/core/src/client.ws-upgrade.test.ts
+++ b/packages/core/src/client.ws-upgrade.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import http from "node:http";
+import type { IncomingMessage } from "node:http";
+import WebSocket, { WebSocketServer } from "ws";
+import { Server as SocketIOServer } from "socket.io";
+import { OutrayClient } from "./client";
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    server.once("error", onError);
+    server.listen(0, () => {
+      server.off("error", onError);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Failed to bind server"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function close(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+test("OutrayClient forwards websocket upgrades to a plain websocket backend", async () => {
+  let connected = false;
+
+  const backendHttpServer = http.createServer();
+  const backend = new WebSocketServer({ server: backendHttpServer });
+  backend.on("connection", (socket) => {
+    connected = true;
+    socket.close();
+  });
+  const backendPort = await listen(backendHttpServer);
+
+  const controlHttpServer = http.createServer();
+  const controlServer = new WebSocketServer({ server: controlHttpServer });
+  const controlPort = await listen(controlHttpServer);
+
+  const client = new OutrayClient({
+    localPort: backendPort,
+    serverUrl: `ws://127.0.0.1:${controlPort}`,
+  });
+
+  const upgradeSeen = new Promise<void>((resolve, reject) => {
+    controlServer.on("connection", (controlSocket) => {
+      controlSocket.once("message", (raw) => {
+        const openTunnel = JSON.parse(raw.toString()) as { type: string };
+        assert.equal(openTunnel.type, "open_tunnel");
+        controlSocket.send(JSON.stringify({ type: "tunnel_opened", url: "http://localhost.direct/test" }));
+
+        controlSocket.once("message", (upgradeRaw) => {
+          const upgrade = JSON.parse(upgradeRaw.toString()) as { type: string; success?: boolean };
+          if (upgrade.type === "ws_upgrade_response" && upgrade.success) {
+            resolve();
+          } else {
+            reject(new Error(`Unexpected upgrade response: ${upgradeRaw.toString()}`));
+          }
+        });
+
+        controlSocket.send(JSON.stringify({
+          type: "ws_upgrade",
+          wsConnectionId: "wsc-test-plain",
+          path: "/socket.io/?EIO=4&transport=websocket",
+          headers: {
+            origin: "https://frontend.example",
+            "user-agent": "Mozilla/5.0",
+          },
+        }));
+      });
+    });
+  });
+
+  client.start();
+  await upgradeSeen;
+
+  assert.equal(connected, true);
+
+  client.stop();
+  await close(controlHttpServer);
+  await close(backendHttpServer);
+});
+
+test("OutrayClient forwards origin so a Socket.IO backend can accept the websocket upgrade", async () => {
+  let upgradeOrigin: string | undefined;
+  let allowed = false;
+
+  const ioServer = new SocketIOServer({
+    cors: {
+      origin: "https://frontend.example",
+      credentials: true,
+    },
+    allowRequest: (req: IncomingMessage, callback: (err: string | null, success: boolean) => void) => {
+      upgradeOrigin = req.headers.origin;
+      allowed = req.headers.origin === "https://frontend.example";
+      callback(null, allowed);
+    },
+  });
+
+  const ioHttpServer = http.createServer();
+  ioServer.attach(ioHttpServer);
+  const backendPort = await listen(ioHttpServer);
+
+  const controlHttpServer = http.createServer();
+  const controlServer = new WebSocketServer({ server: controlHttpServer });
+  const controlPort = await listen(controlHttpServer);
+
+  const client = new OutrayClient({
+    localPort: backendPort,
+    serverUrl: `ws://127.0.0.1:${controlPort}`,
+  });
+
+  const upgradeSeen = new Promise<void>((resolve, reject) => {
+    controlServer.on("connection", (controlSocket) => {
+      controlSocket.once("message", (raw) => {
+        const openTunnel = JSON.parse(raw.toString()) as { type: string };
+        assert.equal(openTunnel.type, "open_tunnel");
+        controlSocket.send(JSON.stringify({ type: "tunnel_opened", url: "http://localhost.direct/test" }));
+
+        controlSocket.once("message", (upgradeRaw) => {
+          const upgrade = JSON.parse(upgradeRaw.toString()) as { type: string; success?: boolean; error?: string };
+          if (upgrade.type === "ws_upgrade_response" && upgrade.success) {
+            resolve();
+          } else {
+            reject(new Error(`Unexpected upgrade response: ${upgradeRaw.toString()}`));
+          }
+        });
+
+        controlSocket.send(JSON.stringify({
+          type: "ws_upgrade",
+          wsConnectionId: "wsc-test-socketio",
+          path: "/socket.io/?EIO=4&transport=websocket",
+          headers: {
+            origin: "https://frontend.example",
+            cookie: "session=abc123",
+            "user-agent": "Mozilla/5.0",
+          },
+        }));
+      });
+    });
+  });
+
+  try {
+    client.start();
+    await upgradeSeen;
+
+    assert.equal(upgradeOrigin, "https://frontend.example");
+    assert.equal(allowed, true);
+  } finally {
+    client.stop();
+    ioServer.close();
+    await close(ioHttpServer);
+    await close(controlHttpServer);
+  }
+});


### PR DESCRIPTION
Fixes #61 

Polling worked through the tunnel but WebSocket upgrades failed. The 
backend never saw the handshake. The problem was in the local ws dialer: 
when the CLI opens the matching ws://localhost connection to the backend, 
it was only forwarding a minimal header set and passing 
Sec-WebSocket-Protocol incorrectly as a plain header instead of through 
the ws constructor's subprotocol argument.

Socket.IO's upgrade handshake is stricter than a bare WebSocket server 
about headers like Origin, which is why this surfaced there specifically 
while plain WebSocket backends tolerated it fine.

### Changes

- Forward relevant browser headers (origin, cookie, authorization, 
  referer, user-agent) from the tunnel edge into the local ws dialer
- Pass subprotocol correctly via the ws constructor's second argument 
  instead of setting Sec-WebSocket-Protocol as a plain header
- Tighten WSProxy to forward only relevant headers rather than replaying 
  all incoming headers including hop-by-hop ones

### Testing

Added `packages/core/src/client.ws-upgrade.test.ts` to prevent this 
regression from coming back. It checks two things: that the tunnel client 
can forward a WebSocket upgrade to a plain WebSocket backend, and that it 
preserves the headers Socket.IO cares about, especially Origin, so a 
Socket.IO server can accept the upgrade instead of staying stuck on 
polling or timing out.

In short, the test proves the tunnel is replaying the browser's upgrade 
context correctly, not just opening a socket.

Both cases pass locally. Also built core, CLI, and tunnel packages, 
all clean.